### PR TITLE
Version check

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ See http://www.smartfoxserver.com
     smartfox configure /path/to/smartfox /path/to/template/dir
 
     smartfox start /path/to/smartfox
+    
 
 ## Help
 
@@ -34,6 +35,24 @@ See http://www.smartfoxserver.com
 The version of this gem is tied to the real version of SmartFox Server.
 
 Example: Gem version 2.3.0.x contains SmartFox Server version 2.3.0.
+
+## Version check
+
+To enable gem version verification, add a version file to your template folder.
+
+Example: `.../version`
+```
+2.16.0
+```
+
+If the version is not satisfied, the following output is printed:
+```
+Configuration failed!
+
+Your rubyfox-server version: 2.15.0.0
+Needed version: ~>2.16.0
+```
+
 
 ## Contributing
 

--- a/lib/rubyfox/server/cli.rb
+++ b/lib/rubyfox/server/cli.rb
@@ -1,9 +1,9 @@
-require 'thor'
-require 'mime/types'
+require "thor"
+require "mime/types"
 
-require 'rubyfox/server'
-require 'rubyfox/server/version'
-require 'rubyfox/server/environment'
+require "rubyfox/server"
+require "rubyfox/server/version"
+require "rubyfox/server/environment"
 
 module Rubyfox
   module Server
@@ -15,6 +15,7 @@ module Rubyfox
       end
 
       desc "install TARGET_DIR", "Install SmartFox Server into TARGET_DIR"
+
       def install(target_dir)
         if File.exist?(target_dir)
           abort "Directory #{target_dir} already exists!"
@@ -50,6 +51,7 @@ module Rubyfox
       end
 
       desc "version", "Display version of this command"
+
       def version
         puts Rubyfox::Server::VERSION
       end


### PR DESCRIPTION
Add verification of the gem version to `smartfox configure` command.

To enable gem verification, add a `version` file to your template folder.

Example: `.../version`
```
2.16.0
```

If the version is not satisfied, the following output is printed:
```
Configuration failed!

Your rubyfox-server version: 2.15.0.0
Needed version: ~>2.16.0
```

@jbnt WDYT?